### PR TITLE
feat: add npm update step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,11 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
 
+      - name: Update npm
+        run: |
+          npm install -g npm@latest
+          npm -v
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
This pull request makes a minor update to the release workflow by ensuring that the latest version of npm is installed before dependencies are installed. This helps prevent issues caused by outdated npm versions during the release process.

* Updated the `.github/workflows/release.yml` workflow to install the latest version of npm before running `npm ci`, ensuring compatibility and reducing potential install issues.