### PR TITLE
fix: update publishing commands for stable releases and remove prerel…

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -66,7 +66,7 @@ Consumers can install prereleases with:
 npm install @devsym/graph-toolkit-react@next
 ```
 
-When ready for stable releases, update the workflow publish command from `--tag next` to `--tag latest`.
+When ready for stable releases, exit prerelease mode (`npx changeset pre exit`) and switch `publishConfig.tag` to `latest`.
 
 ## Manual Commands (maintainers)
 
@@ -74,7 +74,7 @@ Use these only for local validation, not routine publishing:
 
 ```bash
 npm run version-packages
-npm run publish-packages -- --tag next
+npm run publish-packages
 ```
 
 ## Best Practices

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dev": "vite build --watch",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "publish-packages": "changeset publish --tag next --provenance",
+    "publish-packages": "changeset publish --provenance",
     "type-check": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint src --ext .ts,.tsx --fix",


### PR DESCRIPTION
This pull request updates the publishing workflow to clarify and simplify the process for releasing stable versions and managing prerelease tags. The main focus is on ensuring maintainers use the correct commands and configurations when moving from prerelease to stable releases.

Publishing workflow updates:

* Updated the `publish-packages` script in `package.json` to remove the `--tag next` flag, ensuring that published packages use the default tag unless otherwise specified.
* Clarified instructions in `PUBLISHING.md` for transitioning from prerelease to stable releases, including running `npx changeset pre exit` and updating `publishConfig.tag` to `latest`.
* Updated manual publishing instructions in `PUBLISHING.md` to remove the `--tag next` flag from the `npm run publish-packages` command, aligning documentation with the new script behavior.