### PR TITLE
Add sorting and selectFields to usePeopleList

### DIFF
--- a/.changeset/small-suns-sort.md
+++ b/.changeset/small-suns-sort.md
@@ -1,0 +1,5 @@
+---
+"@devsym/graph-toolkit-react": patch
+---
+
+Add `usePeopleList` support for selecting additional user fields and sorting resolved people by `displayName`, `givenName`, or `surname`, expose the related name fields on public people types, and document the pattern in Storybook plus the React MSAL sample.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devsym/graph-toolkit-react",
-  "version": "1.0.0-next.11",
+  "version": "1.0.0-next.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@devsym/graph-toolkit-react",
-      "version": "1.0.0-next.11",
+      "version": "1.0.0-next.14",
       "license": "MIT",
       "dependencies": {
         "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,35 @@ You can also provide people directly or resolve specific users:
 />
 ```
 
+If your app stores only object IDs and needs a sortable list, use `usePeopleList` to
+resolve the users first and then render your own list UI:
+
+```tsx
+import { Person, usePeopleList } from '@devsym/graph-toolkit-react';
+
+function TeamList({ objectIds }: { objectIds: string[] }) {
+  const { people, loading } = usePeopleList({
+    userIds: objectIds,
+    sortBy: 'surname',
+    selectFields: ['givenName', 'surname'],
+  });
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <ul>
+      {people.map(person => (
+        <li key={person.id}>
+          <Person userId={person.id} view="twolines" />
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
 
 ## 🚀 Getting Started
 

--- a/readme.md
+++ b/readme.md
@@ -180,7 +180,7 @@ function TeamList({ objectIds }: { objectIds: string[] }) {
     <ul>
       {people.map(person => (
         <li key={person.id}>
-          <Person userId={person.id} view="twolines" />
+          <Person personDetails={person} view="twolines" />
         </li>
       ))}
     </ul>

--- a/samples/react-msal-sample/README.md
+++ b/samples/react-msal-sample/README.md
@@ -13,6 +13,7 @@ This sample demonstrates how to use **@devsym/graph-toolkit-react** with MSAL (M
 - ✅ Person component displaying current user ("me" query)
 - ✅ People component for compact avatar groups and overflow
 - ✅ PeoplePicker component for searching and selecting people
+- ✅ Selected user list demo that stores picker IDs and renders a sorted roster
 - ✅ Fluent UI design system
 - ✅ TypeScript support
 - ✅ Native `@azure/msal-browser` provider wired to `GraphProvider`
@@ -99,6 +100,7 @@ This sample keeps app-specific wiring in local files and relies on the main pack
 - `src/PersonPage.tsx` demonstrates the `Person` component with `userId="me"`
 - `src/PeoplePage.tsx` demonstrates the `People` component
 - `src/PeoplePickerPage.tsx` demonstrates the `PeoplePicker` component
+- `src/SelectedPeopleListPage.tsx` demonstrates storing picker IDs and resolving a sorted list with `usePeopleList`
 
 For current provider and component usage guidance, use [Graph Toolkit React Documentation](../../readme.md).
 
@@ -113,6 +115,7 @@ src/
 ├── PersonPage.tsx         # Person component demo page
 ├── PeoplePage.tsx         # People component demo page
 ├── PeoplePickerPage.tsx   # PeoplePicker component demo page
+├── SelectedPeopleListPage.tsx # Picker-driven user list demo page
 ├── main.tsx               # App entry point
 └── index.css              # Global styles
 ```

--- a/samples/react-msal-sample/src/Dashboard.tsx
+++ b/samples/react-msal-sample/src/Dashboard.tsx
@@ -17,8 +17,9 @@ import {
 import { PersonPage } from './PersonPage';
 import { PeoplePage } from './PeoplePage';
 import { PeoplePickerPage } from './PeoplePickerPage';
+import { SelectedPeopleListPage } from './SelectedPeopleListPage';
 
-type NavPage = 'person' | 'people' | 'people-picker';
+type NavPage = 'person' | 'people' | 'people-picker' | 'selected-people-list';
 
 const useStyles = makeStyles({
   root: {
@@ -102,6 +103,9 @@ export const Dashboard: React.FC = () => {
             <Tab value="people-picker" icon={<People24Regular />}>
               People Picker
             </Tab>
+            <Tab value="selected-people-list" icon={<People24Regular />}>
+              Selected User List
+            </Tab>
           </TabList>
         </nav>
 
@@ -109,6 +113,7 @@ export const Dashboard: React.FC = () => {
           {activePage === 'person' && <PersonPage />}
           {activePage === 'people' && <PeoplePage />}
           {activePage === 'people-picker' && <PeoplePickerPage />}
+          {activePage === 'selected-people-list' && <SelectedPeopleListPage />}
         </main>
       </div>
     </div>

--- a/samples/react-msal-sample/src/Dashboard.tsx
+++ b/samples/react-msal-sample/src/Dashboard.tsx
@@ -104,7 +104,7 @@ export const Dashboard: React.FC = () => {
               People Picker
             </Tab>
             <Tab value="selected-people-list" icon={<People24Regular />}>
-              Selected User List
+              Selected People List
             </Tab>
           </TabList>
         </nav>

--- a/samples/react-msal-sample/src/SelectedPeopleListPage.tsx
+++ b/samples/react-msal-sample/src/SelectedPeopleListPage.tsx
@@ -1,0 +1,162 @@
+import React, { useMemo, useState } from 'react';
+import {
+  PeoplePicker,
+  usePeopleList,
+} from '@devsym/graph-toolkit-react';
+import type { PeoplePickerPerson } from '@devsym/graph-toolkit-react';
+import {
+  Body1,
+  Body2,
+  Caption1,
+  Card,
+  Persona,
+  Spinner,
+  Title3,
+  makeStyles,
+  tokens,
+} from '@fluentui/react-components';
+import { People24Regular } from '@fluentui/react-icons';
+
+const useStyles = makeStyles({
+  card: {
+    maxWidth: '760px',
+    padding: '32px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '24px',
+  },
+  header: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    alignItems: 'center',
+    textAlign: 'center',
+  },
+  info: {
+    padding: '16px',
+    backgroundColor: tokens.colorNeutralBackground2,
+    borderRadius: tokens.borderRadiusMedium,
+    borderLeft: `4px solid ${tokens.colorBrandBackground}`,
+  },
+  section: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+    padding: '24px',
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderRadius: tokens.borderRadiusMedium,
+  },
+  codeBlock: {
+    margin: 0,
+    padding: '12px 16px',
+    backgroundColor: tokens.colorNeutralBackground3,
+    borderRadius: tokens.borderRadiusMedium,
+    overflowX: 'auto',
+    fontFamily: 'Consolas, "Courier New", monospace',
+    fontSize: tokens.fontSizeBase200,
+    lineHeight: tokens.lineHeightBase200,
+  },
+  peopleList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+  },
+});
+
+const getPersonLabel = (person: {
+  displayName?: string | null;
+  mail?: string | null;
+  userPrincipalName?: string | null;
+  id: string;
+}) => person.displayName ?? person.mail ?? person.userPrincipalName ?? person.id;
+
+export const SelectedPeopleListPage: React.FC = () => {
+  const styles = useStyles();
+  const [selectedPeople, setSelectedPeople] = useState<PeoplePickerPerson[]>([]);
+  const storedUserIds = useMemo(() => selectedPeople.map(person => person.id), [selectedPeople]);
+  const peopleListOptions = useMemo(
+    () => (storedUserIds.length > 0
+      ? {
+        userIds: storedUserIds,
+        sortBy: 'surname' as const,
+        selectFields: ['givenName', 'surname'],
+      }
+      : {
+        people: [],
+        sortBy: 'surname' as const,
+        selectFields: ['givenName', 'surname'],
+      }),
+    [storedUserIds]
+  );
+  const { people, loading } = usePeopleList(peopleListOptions);
+
+  return (
+    <Card className={styles.card}>
+      <div className={styles.header}>
+        <People24Regular style={{ fontSize: '48px', color: tokens.colorBrandBackground }} />
+        <Title3>Selected People List</Title3>
+      </div>
+
+      <div className={styles.info}>
+        <Body1>
+          This page demonstrates a common consumer pattern: the picker controls selection, the app
+          stores only object IDs, and <code>usePeopleList</code> resolves a sorted list for display.
+        </Body1>
+      </div>
+
+      <div className={styles.section}>
+        <Body1>Choose people</Body1>
+        <PeoplePicker
+          selectedPeople={selectedPeople}
+          onSelectionChange={setSelectedPeople}
+          placeholder="Search for people and build a list..."
+          maxPeople={8}
+        />
+        <Caption1>
+          Requires <code>User.ReadBasic.All</code> for picker suggestions and loading other users by
+          ID.
+        </Caption1>
+      </div>
+
+      <div className={styles.section}>
+        <Body1>Stored object IDs</Body1>
+        <Caption1>
+          This is the minimal data the app persists from the picker selection.
+        </Caption1>
+        <pre className={styles.codeBlock}>
+          {storedUserIds.length > 0 ? JSON.stringify(storedUserIds, null, 2) : '[]'}
+        </pre>
+      </div>
+
+      <div className={styles.section}>
+        <Body1>Resolved users sorted by surname</Body1>
+        <Caption1>
+          The list below is loaded from the stored IDs with <code>usePeopleList</code> and sorted by
+          <code>surname</code>.
+        </Caption1>
+
+        {storedUserIds.length === 0 ? (
+          <Body2>Select people above to populate the list.</Body2>
+        ) : loading ? (
+          <Spinner label="Resolving selected users..." size="tiny" />
+        ) : (
+          <div className={styles.peopleList}>
+            {people.map(person => (
+              <Persona
+                key={person.id}
+                name={getPersonLabel(person)}
+                primaryText={getPersonLabel(person)}
+                secondaryText={person.jobTitle ?? person.mail ?? undefined}
+                tertiaryText={person.department ?? undefined}
+                avatar={{
+                  image: person.photoUrl ? { src: person.photoUrl } : undefined,
+                  name: getPersonLabel(person),
+                }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+};

--- a/src/__tests__/usePeopleList.test.ts
+++ b/src/__tests__/usePeopleList.test.ts
@@ -9,6 +9,8 @@ import type { IPersonDataProvider } from '../providers/IPersonDataProvider';
 type GraphUsersResponse = {
   value: Array<{
     id: string;
+    givenName?: string | null;
+    surname?: string | null;
     displayName: string;
     mail?: string | null;
     userPrincipalName?: string | null;
@@ -212,6 +214,82 @@ describe('usePeopleList', () => {
     expect(getPersonData).toHaveBeenCalledTimes(1);
   });
 
+  it('does not refetch when rerendered with equivalent selectFields values', async () => {
+    const getPersonData = vi.fn().mockResolvedValue({
+      user: {
+        id: 'user-1',
+        displayName: 'Adele Vance',
+        givenName: 'Adele',
+        surname: 'Vance',
+        mail: 'adelev@contoso.com',
+        userPrincipalName: 'adelev@contoso.com',
+      },
+      presence: null,
+      photoUrl: null,
+    });
+
+    mockedUseProvider.mockReturnValue({
+      getPersonData,
+    } as IProvider & IPersonDataProvider as never);
+
+    const { result, rerender } = renderHook(
+      ({ fields }) => usePeopleList({ userIds: ['user-1'], sortBy: 'surname', selectFields: fields }),
+      {
+        initialProps: { fields: ['givenName', 'surname'] },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    rerender({ fields: ['givenName', 'surname'] });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getPersonData).toHaveBeenCalledTimes(1);
+  });
+
+  it('sorts resolved userIds by surname and forwards normalized custom fields to the provider', async () => {
+    const directory = new Map([
+      ['user-3', { id: 'user-3', displayName: 'Charlie Adams', givenName: 'Charlie', surname: 'Adams' }],
+      ['user-1', { id: 'user-1', displayName: 'Adele Zane', givenName: 'Adele', surname: 'Zane' }],
+      ['user-2', { id: 'user-2', displayName: 'Ben Cooper', givenName: 'Ben', surname: 'Cooper' }],
+    ]);
+
+    const getPersonData = vi.fn().mockImplementation(async ({ identifier }) => ({
+      user: directory.get(identifier),
+      presence: null,
+      photoUrl: null,
+    }));
+
+    mockedUseProvider.mockReturnValue({
+      getPersonData,
+    } as IProvider & IPersonDataProvider as never);
+
+    const { result } = renderHook(() =>
+      usePeopleList({
+        userIds: ['user-3', 'user-1', 'user-2'],
+        sortBy: 'surname',
+        selectFields: ['  givenName  ', '', 'bad&field', 'surname'],
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.people.map(person => person.id)).toEqual(['user-3', 'user-2', 'user-1']);
+    expect(getPersonData).toHaveBeenNthCalledWith(1, {
+      identifier: 'user-3',
+      fetchPresence: false,
+      fetchPhoto: true,
+      selectFields: ['givenName', 'surname'],
+    });
+  });
+
   it('loads group members from Graph when groupId is provided', async () => {
     mockedUseProvider.mockReturnValue({
       getPersonData: vi.fn().mockResolvedValue({
@@ -250,6 +328,8 @@ describe('usePeopleList', () => {
     expect(result.current.people).toEqual([
       {
         id: 'user-1',
+        givenName: null,
+        surname: null,
         displayName: 'Adele Vance',
         mail: 'adelev@contoso.com',
         userPrincipalName: 'adelev@contoso.com',
@@ -257,6 +337,47 @@ describe('usePeopleList', () => {
         department: 'Marketing',
       },
     ]);
+  });
+
+  it('adds the requested sort field to Graph select queries and sorts the result', async () => {
+    mockedUseProvider.mockReturnValue({
+      getPersonData: vi.fn().mockResolvedValue({
+        user: null,
+        presence: null,
+        photoUrl: null,
+      }),
+    } as IProvider & IPersonDataProvider as never);
+
+    const getMock = vi.fn().mockResolvedValue({
+      value: [
+        {
+          id: 'user-2',
+          givenName: 'Zoe',
+          displayName: 'Zoe Hall',
+          mail: 'zoe.hall@contoso.com',
+        },
+        {
+          id: 'user-1',
+          givenName: 'Adele',
+          displayName: 'Adele Vance',
+          mail: 'adele.vance@contoso.com',
+        },
+      ],
+    });
+    const topMock = vi.fn().mockReturnValue({ get: getMock });
+    const selectMock = vi.fn().mockReturnValue({ top: topMock });
+    const apiMock = vi.fn().mockReturnValue({ select: selectMock });
+
+    mockedUseGraphClient.mockReturnValue({ api: apiMock } as never);
+
+    const { result } = renderHook(() => usePeopleList({ maxPeople: 2, sortBy: 'givenName' }));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(selectMock).toHaveBeenCalledWith('id,displayName,mail,userPrincipalName,jobTitle,department,givenName');
+    expect(result.current.people.map(person => person.id)).toEqual(['user-1', 'user-2']);
   });
 
   it('loads default tenant users from Graph when no explicit source is provided', async () => {
@@ -296,6 +417,8 @@ describe('usePeopleList', () => {
     expect(result.current.people).toEqual([
       {
         id: 'user-1',
+        givenName: null,
+        surname: null,
         displayName: 'Unknown Person',
         mail: 'unknown.person@contoso.com',
         userPrincipalName: 'unknown.person@contoso.com',

--- a/src/__tests__/usePeopleList.test.ts
+++ b/src/__tests__/usePeopleList.test.ts
@@ -252,6 +252,43 @@ describe('usePeopleList', () => {
     expect(getPersonData).toHaveBeenCalledTimes(1);
   });
 
+  it('does not refetch when selectFields contains only default fields', async () => {
+    const getPersonData = vi.fn().mockResolvedValue({
+      user: {
+        id: 'user-1',
+        displayName: 'Adele Vance',
+        givenName: 'Adele',
+        surname: 'Vance',
+        mail: 'adelev@contoso.com',
+        userPrincipalName: 'adelev@contoso.com',
+      },
+      presence: null,
+      photoUrl: null,
+    });
+
+    mockedUseProvider.mockReturnValue({
+      getPersonData,
+    } as IProvider & IPersonDataProvider as never);
+
+    const { result, rerender } = renderHook(
+      ({ fields }: { fields?: string[] }) => usePeopleList({ userIds: ['user-1'], selectFields: fields }),
+      { initialProps: { fields: undefined } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Re-render with default fields explicitly listed — should not trigger a new fetch
+    rerender({ fields: ['displayName', 'mail', 'id'] });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getPersonData).toHaveBeenCalledTimes(1);
+  });
+
   it('sorts resolved userIds by surname and forwards normalized custom fields to the provider', async () => {
     const directory = new Map([
       ['user-3', { id: 'user-3', displayName: 'Charlie Adams', givenName: 'Charlie', surname: 'Adams' }],

--- a/src/components/People/People.tsx
+++ b/src/components/People/People.tsx
@@ -68,6 +68,9 @@ const renderAvatarGroupItem = (person: PeoplePerson) => {
 export const People: React.FC<PeopleProps> = ({
   people,
   userIds,
+  selectFields,
+  sortBy,
+  sortDirection,
   groupId,
   showMax = DEFAULT_SHOW_MAX,
   showPresence = false,
@@ -79,6 +82,9 @@ export const People: React.FC<PeopleProps> = ({
   const { people: resolvedPeople, loading, error } = usePeopleList({
     people,
     userIds,
+    selectFields,
+    sortBy,
+    sortDirection,
     groupId,
     maxPeople: Math.max(DEFAULT_FETCH_COUNT, showMax + 5),
     showPresence,

--- a/src/components/People/People.types.ts
+++ b/src/components/People/People.types.ts
@@ -6,6 +6,16 @@ import type { AvatarGroupProps } from '@fluentui/react-components';
 import type { PeopleSearchResult } from '../../providers/IPersonDataProvider';
 
 /**
+ * Supported built-in sort fields for resolved people collections.
+ */
+export type PeopleSortField = 'displayName' | 'givenName' | 'surname';
+
+/**
+ * Sort direction for resolved people collections.
+ */
+export type PeopleSortDirection = 'asc' | 'desc';
+
+/**
  * Triggers reported by the {@link PeopleProps.onUpdated} callback.
  */
 export type PeopleUpdateTrigger = 'peopleChanged' | 'peopleLoaded' | 'peopleLoadFailed';
@@ -66,6 +76,23 @@ export interface PeopleProps extends Omit<AvatarGroupProps, 'children'> {
    * Values can be Microsoft Graph user IDs, UPNs, email addresses, or `"me"`.
    */
   userIds?: string[];
+
+  /**
+   * Additional Graph user fields to request when the component resolves people.
+   */
+  selectFields?: string[];
+
+  /**
+   * Field used to sort the resolved people collection.
+   */
+  sortBy?: PeopleSortField;
+
+  /**
+   * Direction used when {@link PeopleProps.sortBy} is provided.
+   *
+   * Defaults to `asc`.
+   */
+  sortDirection?: PeopleSortDirection;
 
   /**
    * The ID of a Microsoft Entra ID group whose direct user members should be rendered.

--- a/src/components/Person/Person.types.ts
+++ b/src/components/Person/Person.types.ts
@@ -20,6 +20,14 @@ export type PersonUpdateTrigger = 'personDetailsChanged' | 'personLoaded' | 'per
  */
 export interface PersonDetails {
   /**
+   * The person's first name.
+   */
+  givenName?: string | null;
+  /**
+   * The person's last name.
+   */
+  surname?: string | null;
+  /**
    * The person's display name.
    */
   displayName?: string | null;

--- a/src/hooks/usePeopleList.ts
+++ b/src/hooks/usePeopleList.ts
@@ -210,7 +210,9 @@ export const usePeopleList = (options?: UsePeopleListOptions): UsePeopleListResu
   const providerState = useProviderState();
   const directPeopleKey = JSON.stringify(options?.people ?? null);
   const userIdsKey = JSON.stringify(uniqueNonEmpty(options?.userIds));
-  const customSelectFieldsKey = JSON.stringify(toSelectableFields(options?.selectFields));
+  const customSelectFieldsKey = JSON.stringify(
+    toSelectableFields(options?.selectFields).filter(f => !DEFAULT_PEOPLE_SELECT_FIELD_SET.has(f))
+  );
   const directPeople = useMemo<PeoplePerson[] | undefined>(() => {
     if (directPeopleKey === 'null') {
       return undefined;

--- a/src/hooks/usePeopleList.ts
+++ b/src/hooks/usePeopleList.ts
@@ -10,12 +10,25 @@ import {
   isPeopleSearchProvider,
   isPersonDataProvider,
 } from '../providers/IPersonDataProvider';
-import type { PeoplePerson } from '../components/People/People.types';
+import type {
+  PeoplePerson,
+  PeopleSortDirection,
+  PeopleSortField,
+} from '../components/People/People.types';
 import { encodeGraphPathSegment, photoResponseToDataUrl } from '../utils/graph';
 
-const PEOPLE_SELECT_FIELDS = 'id,displayName,mail,userPrincipalName,jobTitle,department';
-const GROUP_MEMBERS_SELECT_FIELDS = 'id,displayName,mail,userPrincipalName,jobTitle,department';
+const DEFAULT_PEOPLE_SELECT_FIELDS = [
+  'id',
+  'displayName',
+  'mail',
+  'userPrincipalName',
+  'jobTitle',
+  'department',
+] as const;
+const DEFAULT_PEOPLE_SELECT_FIELD_SET = new Set<string>(DEFAULT_PEOPLE_SELECT_FIELDS);
 const DEFAULT_MAX_PEOPLE = 10;
+const VALID_SELECT_FIELD_PATTERN = /^[a-zA-Z0-9_./]+$/;
+const DEFAULT_SORT_DIRECTION: PeopleSortDirection = 'asc';
 
 /**
  * Options for the {@link usePeopleList} hook.
@@ -29,6 +42,18 @@ export interface UsePeopleListOptions {
    * User identifiers to resolve into person entries.
    */
   userIds?: string[];
+  /**
+   * Additional Graph user fields to request while resolving people.
+   */
+  selectFields?: string[];
+  /**
+   * Field used to sort the resolved people collection.
+   */
+  sortBy?: PeopleSortField;
+  /**
+   * Direction used when {@link sortBy} is provided.
+   */
+  sortDirection?: PeopleSortDirection;
   /**
    * Group ID whose direct members should be loaded.
    */
@@ -65,6 +90,8 @@ export interface UsePeopleListResult {
 
 const mapGraphUser = (user: User): PeoplePerson => ({
   id: user.id ?? user.userPrincipalName ?? user.mail ?? 'unknown-user',
+  givenName: user.givenName ?? null,
+  surname: user.surname ?? null,
   displayName: user.displayName ?? null,
   mail: user.mail ?? null,
   userPrincipalName: user.userPrincipalName ?? null,
@@ -101,6 +128,70 @@ const resolveDirectPersonIdentifier = (
 const uniqueNonEmpty = (values?: string[]): string[] =>
   Array.from(new Set((values ?? []).map(value => value.trim()).filter(Boolean)));
 
+const toSelectableFields = (fields?: string[]): string[] =>
+  Array.from(
+    new Set(
+      (fields ?? [])
+        .map(field => field.trim())
+        .filter(field => field.length > 0 && VALID_SELECT_FIELD_PATTERN.test(field))
+    )
+  );
+
+const buildSelectFields = (selectFields?: string[], sortBy?: PeopleSortField): string[] => {
+  const resolvedFields = [...DEFAULT_PEOPLE_SELECT_FIELDS, ...toSelectableFields(selectFields)];
+
+  if (sortBy === 'givenName' || sortBy === 'surname') {
+    resolvedFields.push(sortBy);
+  }
+
+  return Array.from(new Set(resolvedFields));
+};
+
+const getProviderSelectFields = (selectFields: string[]): string[] | undefined => {
+  const customFields = selectFields.filter(field => !DEFAULT_PEOPLE_SELECT_FIELD_SET.has(field));
+
+  return customFields.length > 0 ? customFields : undefined;
+};
+
+const getSortValue = (person: PeoplePerson, sortBy: PeopleSortField): string => {
+  const primary = person[sortBy];
+
+  if (typeof primary === 'string' && primary.trim().length > 0) {
+    return primary;
+  }
+
+  return person.displayName ?? person.mail ?? person.userPrincipalName ?? person.id;
+};
+
+const sortPeople = (
+  people: PeoplePerson[],
+  sortBy?: PeopleSortField,
+  sortDirection: PeopleSortDirection = DEFAULT_SORT_DIRECTION,
+): PeoplePerson[] => {
+  if (!sortBy) {
+    return people;
+  }
+
+  const collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true });
+  const direction = sortDirection === 'desc' ? -1 : 1;
+
+  return people
+    .map((person, index) => ({ person, index }))
+    .sort((left, right) => {
+      const comparison = collator.compare(
+        getSortValue(left.person, sortBy),
+        getSortValue(right.person, sortBy)
+      );
+
+      if (comparison !== 0) {
+        return comparison * direction;
+      }
+
+      return left.index - right.index;
+    })
+    .map(entry => entry.person);
+};
+
 /**
  * Hook to load a compact people list for the {@link People} component.
  *
@@ -118,6 +209,8 @@ export const usePeopleList = (options?: UsePeopleListOptions): UsePeopleListResu
   const provider = useProvider();
   const providerState = useProviderState();
   const directPeopleKey = JSON.stringify(options?.people ?? null);
+  const userIdsKey = JSON.stringify(uniqueNonEmpty(options?.userIds));
+  const customSelectFieldsKey = JSON.stringify(toSelectableFields(options?.selectFields));
   const directPeople = useMemo<PeoplePerson[] | undefined>(() => {
     if (directPeopleKey === 'null') {
       return undefined;
@@ -125,10 +218,21 @@ export const usePeopleList = (options?: UsePeopleListOptions): UsePeopleListResu
 
     return JSON.parse(directPeopleKey) as PeoplePerson[];
   }, [directPeopleKey]);
-  const userIds = useMemo(() => uniqueNonEmpty(options?.userIds), [options?.userIds]);
+  const userIds = useMemo<string[]>(() => JSON.parse(userIdsKey) as string[], [userIdsKey]);
+  const customSelectFields = useMemo<string[]>(
+    () => JSON.parse(customSelectFieldsKey) as string[],
+    [customSelectFieldsKey]
+  );
+  const selectFields = useMemo(
+    () => buildSelectFields(customSelectFields, options?.sortBy),
+    [customSelectFields, options?.sortBy]
+  );
+  const providerSelectFields = useMemo(() => getProviderSelectFields(selectFields), [selectFields]);
   const groupId = useMemo(() => options?.groupId?.trim(), [options?.groupId]);
   const maxPeople = options?.maxPeople ?? DEFAULT_MAX_PEOPLE;
   const showPresence = options?.showPresence ?? false;
+  const sortBy = options?.sortBy;
+  const sortDirection = options?.sortDirection ?? DEFAULT_SORT_DIRECTION;
 
   const [state, setState] = useState<UsePeopleListResult>({
     people: [],
@@ -145,6 +249,7 @@ export const usePeopleList = (options?: UsePeopleListOptions): UsePeopleListResu
           identifier,
           fetchPresence: showPresence,
           fetchPhoto: true,
+          selectFields: providerSelectFields,
         });
 
         if (!response.user) {
@@ -166,7 +271,7 @@ export const usePeopleList = (options?: UsePeopleListOptions): UsePeopleListResu
       const isCurrentUserQuery = identifier.toLowerCase() === 'me';
       const user = (await graphClient
         .api(isCurrentUserQuery ? '/me' : `/users/${encodeGraphPathSegment(identifier)}`)
-        .select(PEOPLE_SELECT_FIELDS)
+        .select(selectFields.join(','))
         .get()) as User;
 
       let presence: Presence | null = null;
@@ -261,7 +366,7 @@ export const usePeopleList = (options?: UsePeopleListOptions): UsePeopleListResu
           ? await enrichResolvedPeople(directPeople, resolveDirectPersonIdentifier)
           : directPeople;
         if (!cancelled) {
-          setState({ people: nextPeople, loading: false, error: null });
+          setState({ people: sortPeople(nextPeople, sortBy, sortDirection), loading: false, error: null });
         }
         return;
       }
@@ -272,7 +377,7 @@ export const usePeopleList = (options?: UsePeopleListOptions): UsePeopleListResu
           .flatMap(result => (result.status === 'fulfilled' && result.value ? [result.value] : []));
 
         if (!cancelled) {
-          setState({ people: nextPeople, loading: false, error: null });
+          setState({ people: sortPeople(nextPeople, sortBy, sortDirection), loading: false, error: null });
         }
         return;
       }
@@ -291,7 +396,7 @@ export const usePeopleList = (options?: UsePeopleListOptions): UsePeopleListResu
           if (graphClient && providerState === 'SignedIn') {
             const response = (await graphClient
               .api(`/groups/${encodeGraphPathSegment(groupId)}/members/microsoft.graph.user`)
-              .select(GROUP_MEMBERS_SELECT_FIELDS)
+              .select(selectFields.join(','))
               .top(maxPeople)
               .get()) as { value?: User[] };
             nextPeople = (response.value ?? []).map(mapGraphUser);
@@ -305,7 +410,7 @@ export const usePeopleList = (options?: UsePeopleListOptions): UsePeopleListResu
         } else if (graphClient && providerState === 'SignedIn') {
           const response = (await graphClient
             .api('/users')
-            .select(PEOPLE_SELECT_FIELDS)
+            .select(selectFields.join(','))
             .top(maxPeople)
             .get()) as { value?: User[] };
           nextPeople = (response.value ?? []).map(mapGraphUser);
@@ -316,7 +421,7 @@ export const usePeopleList = (options?: UsePeopleListOptions): UsePeopleListResu
         }
 
         if (!cancelled) {
-          setState({ people: nextPeople, loading: false, error: null });
+          setState({ people: sortPeople(nextPeople, sortBy, sortDirection), loading: false, error: null });
         }
       } catch (error) {
         if (!cancelled) {
@@ -330,7 +435,21 @@ export const usePeopleList = (options?: UsePeopleListOptions): UsePeopleListResu
     return () => {
       cancelled = true;
     };
-  }, [directPeople, directPeopleKey, graphClient, groupId, maxPeople, provider, providerState, showPresence, userIds]);
+  }, [
+    directPeople,
+    directPeopleKey,
+    graphClient,
+    groupId,
+    maxPeople,
+    provider,
+    providerSelectFields,
+    providerState,
+    selectFields,
+    showPresence,
+    sortBy,
+    sortDirection,
+    userIds,
+  ]);
 
   return state;
 };

--- a/src/providers/IPersonDataProvider.ts
+++ b/src/providers/IPersonDataProvider.ts
@@ -84,6 +84,14 @@ export interface PeopleSearchResult {
    */
   id: string;
   /**
+   * The person's first name.
+   */
+  givenName?: string | null;
+  /**
+   * The person's last name.
+   */
+  surname?: string | null;
+  /**
    * The person's display name
    */
   displayName?: string | null;

--- a/src/providers/MockProvider.ts
+++ b/src/providers/MockProvider.ts
@@ -19,6 +19,8 @@ type StateListener = () => void;
 const MOCK_PEOPLE: PeopleSearchResult[] = [
   {
     id: '00000000-0000-0000-0000-000000000001',
+    givenName: 'Adele',
+    surname: 'Vance',
     displayName: 'Adele Vance',
     mail: 'adelev@contoso.com',
     userPrincipalName: 'adelev@contoso.com',
@@ -27,6 +29,8 @@ const MOCK_PEOPLE: PeopleSearchResult[] = [
   },
   {
     id: '00000000-0000-0000-0000-000000000002',
+    givenName: 'Alex',
+    surname: 'Wilber',
     displayName: 'Alex Wilber',
     mail: 'alexw@contoso.com',
     userPrincipalName: 'alexw@contoso.com',
@@ -35,6 +39,8 @@ const MOCK_PEOPLE: PeopleSearchResult[] = [
   },
   {
     id: '00000000-0000-0000-0000-000000000003',
+    givenName: 'Diego',
+    surname: 'Siciliani',
     displayName: 'Diego Siciliani',
     mail: 'diegosi@contoso.com',
     userPrincipalName: 'diegosi@contoso.com',
@@ -43,6 +49,8 @@ const MOCK_PEOPLE: PeopleSearchResult[] = [
   },
   {
     id: '00000000-0000-0000-0000-000000000004',
+    givenName: 'Grady',
+    surname: 'Archie',
     displayName: 'Grady Archie',
     mail: 'gradya@contoso.com',
     userPrincipalName: 'gradya@contoso.com',
@@ -51,6 +59,8 @@ const MOCK_PEOPLE: PeopleSearchResult[] = [
   },
   {
     id: '00000000-0000-0000-0000-000000000005',
+    givenName: 'Henrietta',
+    surname: 'Mueller',
     displayName: 'Henrietta Mueller',
     mail: 'henriettam@contoso.com',
     userPrincipalName: 'henriettam@contoso.com',
@@ -59,6 +69,8 @@ const MOCK_PEOPLE: PeopleSearchResult[] = [
   },
   {
     id: '00000000-0000-0000-0000-000000000006',
+    givenName: 'Isaiah',
+    surname: 'Langer',
     displayName: 'Isaiah Langer',
     mail: 'isaiahl@contoso.com',
     userPrincipalName: 'isaiahl@contoso.com',
@@ -67,6 +79,8 @@ const MOCK_PEOPLE: PeopleSearchResult[] = [
   },
   {
     id: '00000000-0000-0000-0000-000000000007',
+    givenName: 'Johanna',
+    surname: 'Lorenz',
     displayName: 'Johanna Lorenz',
     mail: 'johannal@contoso.com',
     userPrincipalName: 'johannal@contoso.com',
@@ -75,6 +89,8 @@ const MOCK_PEOPLE: PeopleSearchResult[] = [
   },
   {
     id: '00000000-0000-0000-0000-000000000008',
+    givenName: 'Joni',
+    surname: 'Sherman',
     displayName: 'Joni Sherman',
     mail: 'jonis@contoso.com',
     userPrincipalName: 'jonis@contoso.com',
@@ -83,6 +99,8 @@ const MOCK_PEOPLE: PeopleSearchResult[] = [
   },
   {
     id: '00000000-0000-0000-0000-000000000009',
+    givenName: 'Lee',
+    surname: 'Gu',
     displayName: 'Lee Gu',
     mail: 'leeg@contoso.com',
     userPrincipalName: 'leeg@contoso.com',
@@ -91,6 +109,8 @@ const MOCK_PEOPLE: PeopleSearchResult[] = [
   },
   {
     id: '00000000-0000-0000-0000-000000000010',
+    givenName: 'Megan',
+    surname: 'Bowen',
     displayName: 'Megan Bowen',
     mail: 'meganb@contoso.com',
     userPrincipalName: 'meganb@contoso.com',
@@ -138,6 +158,8 @@ export class MockProvider implements IProvider, IPersonDataProvider, IPeopleSear
 
     const mockUser: User = {
       id: mockPerson.id,
+      givenName: mockPerson.givenName,
+      surname: mockPerson.surname,
       displayName: mockPerson.displayName,
       userPrincipalName: resolvedUserPrincipalName,
       jobTitle: mockPerson.jobTitle,

--- a/stories/People.stories.tsx
+++ b/stories/People.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
+import { fn } from 'storybook/test';
 import { FluentProvider, Text, webLightTheme } from '@fluentui/react-components';
 import { People } from '../src/components/People';
 import { GraphProvider } from '../src/providers/ProviderContext';
@@ -35,6 +36,9 @@ The component can render a supplied list of people, resolve specific \
       </FluentProvider>
     ),
   ],
+  args: {
+    onUpdated: fn(),
+  },
   argTypes: {
     showMax: {
       control: { type: 'number', min: 0, max: 10 },

--- a/stories/PeoplePicker.stories.tsx
+++ b/stories/PeoplePicker.stories.tsx
@@ -1,12 +1,118 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import React, { useState } from 'react';
-import { FluentProvider, webLightTheme, Text } from '@fluentui/react-components';
+import React, { useMemo, useState } from 'react';
+import { fn } from 'storybook/test';
+import {
+  Caption1,
+  Card,
+  FluentProvider,
+  Persona,
+  Spinner,
+  Text,
+  tokens,
+  webLightTheme,
+} from '@fluentui/react-components';
 import { PeoplePicker } from '../src/components/PeoplePicker';
 import { GraphProvider } from '../src/providers/ProviderContext';
 import { MockProvider } from '../src/providers/MockProvider';
 import type { PeoplePickerPerson } from '../src/components/PeoplePicker';
+import { usePeopleList } from '../src/hooks/usePeopleList';
 
 const provider = new MockProvider({ autoSignIn: true });
+
+type PeoplePickerStoryProps = React.ComponentProps<typeof PeoplePicker>;
+
+const getPersonLabel = (person: { displayName?: string | null; mail?: string | null; userPrincipalName?: string | null; id: string }) =>
+  person.displayName ?? person.mail ?? person.userPrincipalName ?? person.id;
+
+const SelectedUsersListDemo: React.FC<PeoplePickerStoryProps> = (args) => {
+  const [selectedPeople, setSelectedPeople] = useState<PeoplePickerPerson[]>([]);
+  const selectedUserIds = useMemo(() => selectedPeople.map(person => person.id), [selectedPeople]);
+  const peopleListOptions = useMemo(
+    () => (selectedUserIds.length > 0
+      ? {
+        userIds: selectedUserIds,
+        sortBy: 'surname' as const,
+        selectFields: ['givenName', 'surname'],
+      }
+      : {
+        people: [],
+        sortBy: 'surname' as const,
+        selectFields: ['givenName', 'surname'],
+      }),
+    [selectedUserIds]
+  );
+  const { people, loading } = usePeopleList(peopleListOptions);
+  const handleSelectionChange = (nextSelectedPeople: PeoplePickerPerson[]) => {
+    setSelectedPeople(nextSelectedPeople);
+    args.onSelectionChange?.(nextSelectedPeople);
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <PeoplePicker
+        {...args}
+        selectedPeople={selectedPeople}
+        onSelectionChange={handleSelectionChange}
+      />
+
+      <Card
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+          padding: 16,
+          backgroundColor: tokens.colorNeutralBackground2,
+        }}
+      >
+        <Text weight="semibold">Stored object IDs</Text>
+        <Caption1>
+          This mirrors the common app pattern where the picker drives selection, but persistence only
+          stores Microsoft Entra object IDs.
+        </Caption1>
+        <code style={{ whiteSpace: 'pre-wrap' }}>
+          {selectedUserIds.length > 0 ? JSON.stringify(selectedUserIds, null, 2) : '[]'}
+        </code>
+      </Card>
+
+      <Card
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+          padding: 16,
+        }}
+      >
+        <Text weight="semibold">Selected users sorted by surname</Text>
+        <Caption1>
+          The list is resolved with <code>usePeopleList</code> using the stored IDs, then sorted by
+          <code>surname</code>.
+        </Caption1>
+
+        {selectedUserIds.length === 0 ? (
+          <Text>Select a few people to populate the list.</Text>
+        ) : loading ? (
+          <Spinner label="Resolving selected users..." size="tiny" />
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {people.map(person => (
+              <Persona
+                key={person.id}
+                name={getPersonLabel(person)}
+                primaryText={getPersonLabel(person)}
+                secondaryText={person.jobTitle ?? person.mail ?? undefined}
+                tertiaryText={person.department ?? undefined}
+                avatar={{
+                  image: person.photoUrl ? { src: person.photoUrl } : undefined,
+                  name: getPersonLabel(person),
+                }}
+              />
+            ))}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+};
 
 const meta: Meta<typeof PeoplePicker> = {
   title: 'Components/PeoplePicker',
@@ -19,6 +125,9 @@ const meta: Meta<typeof PeoplePicker> = {
         component: `Search and select one or more people from Microsoft Graph using the Fluent UI TagPicker.
 
 The \`PeoplePicker\` supports both **controlled** and **uncontrolled** usage patterns.
+
+See the **Selected Users List** story for the recommended consumer pattern when your app stores
+only object IDs from picker selections and later resolves a sorted list with \`usePeopleList\`.
 
 When wrapping with a \`MockProvider\` (with \`autoSignIn: true\`), it uses built-in mock data so you can prototype without any auth configuration.`,
       },
@@ -35,6 +144,10 @@ When wrapping with a \`MockProvider\` (with \`autoSignIn: true\`), it uses built
       </FluentProvider>
     ),
   ],
+  args: {
+    onSelectionChange: fn(),
+    onUpdated: fn(),
+  },
   argTypes: {
     placeholder: { control: 'text' },
     maxPeople: { control: { type: 'number', min: 1 } },
@@ -101,9 +214,18 @@ export const Controlled: Story = {
       },
     ]);
 
+    const handleSelectionChange = (nextSelectedPeople: PeoplePickerPerson[]) => {
+      setSelected(nextSelectedPeople);
+      args.onSelectionChange?.(nextSelectedPeople);
+    };
+
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-        <PeoplePicker {...args} selectedPeople={selected} onSelectionChange={setSelected} />
+        <PeoplePicker
+          {...args}
+          selectedPeople={selected}
+          onSelectionChange={handleSelectionChange}
+        />
         <Text size={200}>
           Selected: {selected.map((p) => p.displayName).join(', ') || '(none)'}
         </Text>
@@ -112,6 +234,19 @@ export const Controlled: Story = {
   },
   args: {
     placeholder: 'Search for people...',
+  },
+};
+
+/**
+ * Demonstrates the common pattern where the app stores only selected object IDs,
+ * then resolves a sorted user list with `usePeopleList`.
+ */
+export const SelectedUsersList: Story = {
+  name: 'Selected Users List',
+  render: (args) => <SelectedUsersListDemo {...args} />,
+  args: {
+    placeholder: 'Search and add people...',
+    maxPeople: 5,
   },
 };
 

--- a/stories/Person.stories.tsx
+++ b/stories/Person.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
+import { fn } from 'storybook/test';
 import { Person } from '../src/components/Person';
 import { GraphProvider } from '../src/providers/ProviderContext';
 import { MockProvider } from '../src/providers/MockProvider';
@@ -47,6 +48,9 @@ Story organization follows Fluent Persona docs, while Graph-specific stories foc
       );
     },
   ],
+  args: {
+    onUpdated: fn(),
+  },
   argTypes: {
     view: {
       control: 'select',


### PR DESCRIPTION
Support resolving extra Graph user fields and sorting for people lists. usePeopleList now accepts selectFields, sortBy (displayName|givenName|surname) and sortDirection, normalizes custom select fields, forwards non-default fields to providers, and sorts results with a locale-aware collator while preserving stability. Public types (PersonDetails, PeopleSearchResult, People props) expose givenName/surname and new PeopleSortField/PeopleSortDirection types. People component passes through new options to the hook. MockProvider and tests were updated to include name fields and cover selectFields normalization, provider forwarding, and sorting behavior. Storybook and the React MSAL sample include demos (Selected Users List / SelectedPeopleListPage) and args/test helpers to illustrate the pattern. A changeset file was added to document the patch.