### PR TITLE
Refactor Person component to utilize pre-resolved photo URLs 

### DIFF
--- a/.changeset/person-photo-url-support.md
+++ b/.changeset/person-photo-url-support.md
@@ -1,0 +1,5 @@
+---
+'@devsym/graph-toolkit-react': minor
+---
+
+Add `photoUrl` field to `PersonDetails` so callers can supply a pre-resolved profile photo URL. When provided, the `Person` component uses it directly for the avatar image without making an additional fetch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devsym/graph-toolkit-react",
-  "version": "1.0.0-next.14",
+  "version": "1.0.0-next.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@devsym/graph-toolkit-react",
-      "version": "1.0.0-next.14",
+      "version": "1.0.0-next.15",
       "license": "MIT",
       "dependencies": {
         "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/samples/react-msal-sample/src/SelectedPeopleListPage.tsx
+++ b/samples/react-msal-sample/src/SelectedPeopleListPage.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import {
+  Person,
   PeoplePicker,
   usePeopleList,
 } from '@devsym/graph-toolkit-react';
@@ -9,7 +10,6 @@ import {
   Body2,
   Caption1,
   Card,
-  Persona,
   Spinner,
   Title3,
   makeStyles,
@@ -62,13 +62,6 @@ const useStyles = makeStyles({
     gap: '12px',
   },
 });
-
-const getPersonLabel = (person: {
-  displayName?: string | null;
-  mail?: string | null;
-  userPrincipalName?: string | null;
-  id: string;
-}) => person.displayName ?? person.mail ?? person.userPrincipalName ?? person.id;
 
 export const SelectedPeopleListPage: React.FC = () => {
   const styles = useStyles();
@@ -142,16 +135,11 @@ export const SelectedPeopleListPage: React.FC = () => {
         ) : (
           <div className={styles.peopleList}>
             {people.map(person => (
-              <Persona
+              <Person
                 key={person.id}
-                name={getPersonLabel(person)}
-                primaryText={getPersonLabel(person)}
-                secondaryText={person.jobTitle ?? person.mail ?? undefined}
-                tertiaryText={person.department ?? undefined}
-                avatar={{
-                  image: person.photoUrl ? { src: person.photoUrl } : undefined,
-                  name: getPersonLabel(person),
-                }}
+                personDetails={person}
+                view="threelines"
+                fetchImage={false}
               />
             ))}
           </div>

--- a/src/__tests__/Person.test.tsx
+++ b/src/__tests__/Person.test.tsx
@@ -166,6 +166,33 @@ describe('Person', () => {
         expect(onClick).toHaveBeenCalledWith(event);
     });
 
+    it('uses a pre-resolved photoUrl from personDetails without requiring a fetch result', () => {
+        mockedUsePersonData.mockReturnValue({
+            user: null,
+            presence: null,
+            photoUrl: null,
+            loading: false,
+            error: null,
+        });
+
+        render(
+            <Person
+                personDetails={{
+                    id: 'user-1',
+                    displayName: 'Adele Vance',
+                    photoUrl: 'https://contoso.example/avatar.png',
+                }}
+                view="oneline"
+            />
+        );
+
+        const personaProps = getLastPersonaProps();
+        const avatar = personaProps.avatar as { image?: { src?: string }; initials?: string };
+
+        expect(avatar.image?.src).toBe('https://contoso.example/avatar.png');
+        expect(avatar.initials).toBeUndefined();
+    });
+
     it('calls onUpdated after person data loads', () => {
         const onUpdated = vi.fn();
 

--- a/src/components/People/People.types.ts
+++ b/src/components/People/People.types.ts
@@ -4,6 +4,7 @@
 
 import type { AvatarGroupProps } from '@fluentui/react-components';
 import type { PeopleSearchResult } from '../../providers/IPersonDataProvider';
+import type { PersonDetails } from '../Person/Person.types';
 
 /**
  * Supported built-in sort fields for resolved people collections.
@@ -26,7 +27,11 @@ export type PeopleUpdateTrigger = 'peopleChanged' | 'peopleLoaded' | 'peopleLoad
  * This extends the base people search result shape with optional presence fields used
  * for avatar badges when {@link PeopleProps.showPresence} is enabled.
  */
-export interface PeoplePerson extends PeopleSearchResult {
+export type PeoplePerson = PersonDetails & PeopleSearchResult & {
+  /**
+   * Additional custom fields carried on resolved people data.
+   */
+  [key: string]: unknown;
   /**
    * Current presence activity when available.
    */
@@ -35,7 +40,7 @@ export interface PeoplePerson extends PeopleSearchResult {
    * Current presence availability when available.
    */
   presenceAvailability?: string | null;
-}
+};
 
 /**
  * Event payload reported when the {@link People} component finishes a meaningful update.

--- a/src/components/People/People.types.ts
+++ b/src/components/People/People.types.ts
@@ -26,21 +26,9 @@ export type PeopleUpdateTrigger = 'peopleChanged' | 'peopleLoaded' | 'peopleLoad
  *
  * This extends the base people search result shape with optional presence fields used
  * for avatar badges when {@link PeopleProps.showPresence} is enabled.
+ * Presence fields and additional custom fields are inherited from {@link PersonDetails}.
  */
-export type PeoplePerson = PersonDetails & PeopleSearchResult & {
-  /**
-   * Additional custom fields carried on resolved people data.
-   */
-  [key: string]: unknown;
-  /**
-   * Current presence activity when available.
-   */
-  presenceActivity?: string | null;
-  /**
-   * Current presence availability when available.
-   */
-  presenceAvailability?: string | null;
-};
+export type PeoplePerson = PersonDetails & PeopleSearchResult;
 
 /**
  * Event payload reported when the {@link People} component finishes a meaningful update.

--- a/src/components/Person/Person.tsx
+++ b/src/components/Person/Person.tsx
@@ -287,10 +287,14 @@ export const Person: React.FC<PersonProps> = ({
     : undefined;
 
   const resolvedPresence = personaProps.presence ?? defaultPresence;
+  const providedPhotoUrl = typeof resolvedPerson.photoUrl === 'string' && resolvedPerson.photoUrl.length > 0
+    ? resolvedPerson.photoUrl
+    : undefined;
+  const resolvedPhotoUrl = providedPhotoUrl ?? photoUrl ?? undefined;
 
   const resolvedAvatar = personaProps.avatar ?? {
-    image: photoUrl ? { src: photoUrl } : undefined,
-    initials: photoUrl ? undefined : initials,
+    image: resolvedPhotoUrl ? { src: resolvedPhotoUrl } : undefined,
+    initials: resolvedPhotoUrl ? undefined : initials,
     name: displayName,
   };
 

--- a/src/components/Person/Person.types.ts
+++ b/src/components/Person/Person.types.ts
@@ -20,6 +20,13 @@ export type PersonUpdateTrigger = 'personDetailsChanged' | 'personLoaded' | 'per
  */
 export interface PersonDetails {
   /**
+   * A pre-resolved profile photo URL.
+   *
+   * When supplied, the {@link Person} component can render the avatar image without fetching it
+   * again.
+   */
+  photoUrl?: string | null;
+  /**
    * The person's first name.
    */
   givenName?: string | null;

--- a/stories/PeoplePicker.stories.tsx
+++ b/stories/PeoplePicker.stories.tsx
@@ -5,13 +5,13 @@ import {
   Caption1,
   Card,
   FluentProvider,
-  Persona,
   Spinner,
   Text,
   tokens,
   webLightTheme,
 } from '@fluentui/react-components';
 import { PeoplePicker } from '../src/components/PeoplePicker';
+import { Person } from '../src/components/Person';
 import { GraphProvider } from '../src/providers/ProviderContext';
 import { MockProvider } from '../src/providers/MockProvider';
 import type { PeoplePickerPerson } from '../src/components/PeoplePicker';
@@ -20,9 +20,6 @@ import { usePeopleList } from '../src/hooks/usePeopleList';
 const provider = new MockProvider({ autoSignIn: true });
 
 type PeoplePickerStoryProps = React.ComponentProps<typeof PeoplePicker>;
-
-const getPersonLabel = (person: { displayName?: string | null; mail?: string | null; userPrincipalName?: string | null; id: string }) =>
-  person.displayName ?? person.mail ?? person.userPrincipalName ?? person.id;
 
 const SelectedUsersListDemo: React.FC<PeoplePickerStoryProps> = (args) => {
   const [selectedPeople, setSelectedPeople] = useState<PeoplePickerPerson[]>([]);
@@ -95,16 +92,11 @@ const SelectedUsersListDemo: React.FC<PeoplePickerStoryProps> = (args) => {
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
             {people.map(person => (
-              <Persona
+              <Person
                 key={person.id}
-                name={getPersonLabel(person)}
-                primaryText={getPersonLabel(person)}
-                secondaryText={person.jobTitle ?? person.mail ?? undefined}
-                tertiaryText={person.department ?? undefined}
-                avatar={{
-                  image: person.photoUrl ? { src: person.photoUrl } : undefined,
-                  name: getPersonLabel(person),
-                }}
+                personDetails={person}
+                view="threelines"
+                fetchImage={false}
               />
             ))}
           </div>
@@ -159,7 +151,7 @@ When wrapping with a \`MockProvider\` (with \`autoSignIn: true\`), it uses built
     },
     size: {
       control: 'select',
-      options: ['small', 'medium', 'large'],
+      options: ['medium', 'large'],
     },
     disabled: { control: 'boolean' },
   },
@@ -276,11 +268,11 @@ export const MinTwoChars: Story = {
 /**
  * Compact small size variant.
  */
-export const SmallSize: Story = {
-  name: 'Size: Small',
+export const MediumSize: Story = {
+  name: 'Size: Medium',
   args: {
     placeholder: 'Search...',
-    size: 'small',
+    size: 'medium',
   },
 };
 

--- a/stories/PeoplePicker.stories.tsx
+++ b/stories/PeoplePicker.stories.tsx
@@ -266,7 +266,7 @@ export const MinTwoChars: Story = {
 };
 
 /**
- * Compact small size variant.
+ * Medium size variant.
  */
 export const MediumSize: Story = {
   name: 'Size: Medium',


### PR DESCRIPTION
This pull request refactors how people are rendered in the sample and storybook apps by replacing the use of the `Persona` component with the more feature-rich `Person` component. It also improves type safety and flexibility for people data, and adds support for supplying a pre-resolved profile photo URL to avoid unnecessary image fetching. Additionally, the stories and sample code are updated to reflect these changes.

**Component refactoring and feature enhancement:**

* Replaced usage of the `Persona` component with the `Person` component in both `SelectedPeopleListPage.tsx` and `PeoplePicker.stories.tsx`, simplifying the rendering of people and leveraging the new `personDetails` prop and `view` options. (`[[1]](diffhunk://#diff-f7359ea3f520c7893b134d4c87f3c5dadb2e8074981e7cb7f385f4e2cca6ecf1L145-R142)`, `[[2]](diffhunk://#diff-7e65d4e26d3c472c5212a0a5b7e197b513e22c5e515d835df36fdbe8251a132dL98-R99)`)
* Updated the `Person` component to support a pre-resolved `photoUrl` in `personDetails`, ensuring that if a photo URL is provided, it will be used directly for the avatar image without additional fetching. (`[[1]](diffhunk://#diff-822f06186d89a6527eba4a0509cda036364e49ba453ed50760afffff9cfccef9R290-R297)`, `[[2]](diffhunk://#diff-ec7e4cd577c1edaba1bf6d790f8940acc0d14f29e9671d26992d35b41a534f2bR22-R28)`)
* Added a test to verify that the `Person` component correctly uses a provided `photoUrl` from `personDetails`. (`[src/__tests__/Person.test.tsxR169-R195](diffhunk://#diff-0c1b6b7fa6d134134c78511a3f031fe8dad2f7671b9e3d991f8a34f0902cf177R169-R195)`)

**Type improvements:**

* Enhanced the `PeoplePerson` type to extend both `PersonDetails` and `PeopleSearchResult`, allowing for richer and more flexible people data, and added support for additional custom fields. (`[[1]](diffhunk://#diff-59aaf60489deca4a659f71fce495c947292f1decddbaac2e55098d910277b384R7)`, `[[2]](diffhunk://#diff-59aaf60489deca4a659f71fce495c947292f1decddbaac2e55098d910277b384L29-R34)`, `[[3]](diffhunk://#diff-59aaf60489deca4a659f71fce495c947292f1decddbaac2e55098d910277b384L38-R43)`)

**Storybook and sample updates:**

* Removed the `small` size option from the PeoplePicker stories and renamed the "Size: Small" story to "Size: Medium" to reflect current supported sizes. (`[[1]](diffhunk://#diff-7e65d4e26d3c472c5212a0a5b7e197b513e22c5e515d835df36fdbe8251a132dL162-R154)`, `[[2]](diffhunk://#diff-7e65d4e26d3c472c5212a0a5b7e197b513e22c5e515d835df36fdbe8251a132dL279-R275)`)
* Cleaned up unused helper functions and imports related to the old `Persona` component in both the sample and story files. (`[[1]](diffhunk://#diff-f7359ea3f520c7893b134d4c87f3c5dadb2e8074981e7cb7f385f4e2cca6ecf1L12)`, `[[2]](diffhunk://#diff-f7359ea3f520c7893b134d4c87f3c5dadb2e8074981e7cb7f385f4e2cca6ecf1L66-L72)`, `[[3]](diffhunk://#diff-7e65d4e26d3c472c5212a0a5b7e197b513e22c5e515d835df36fdbe8251a132dL8-R14)`, `[[4]](diffhunk://#diff-7e65d4e26d3c472c5212a0a5b7e197b513e22c5e515d835df36fdbe8251a132dL24-L26)`)