### PR TITLE
Enhance People component to display names in overflow popovers

### DIFF
--- a/.changeset/orange-emus-share.md
+++ b/.changeset/orange-emus-share.md
@@ -1,0 +1,5 @@
+---
+"@devsym/graph-toolkit-react": patch
+---
+
+Fix `People` overflow popovers to show each person's name alongside the avatar.

--- a/src/__tests__/People.test.tsx
+++ b/src/__tests__/People.test.tsx
@@ -118,6 +118,10 @@ describe('People', () => {
     expect(firstCallAvatarProps?.badge).toEqual({ status: 'available' });
     expect(firstCallAvatarProps?.image).toEqual({ src: 'photo-1' });
 
+    const overflowCallAvatar = (avatarGroupItemMock.mock.calls[2]?.[0] as {
+      name?: string;
+    });
+    expect(overflowCallAvatar.name).toBe('Alex Wilber');
     expect(avatarGroupPopoverMock).toHaveBeenCalledWith({ count: 1 });
   });
 

--- a/src/__tests__/People.test.tsx
+++ b/src/__tests__/People.test.tsx
@@ -110,10 +110,13 @@ describe('People', () => {
     expect(screen.getByTestId('avatar-group-popover-count').textContent).toBe('+1');
 
     const firstCallAvatar = (avatarGroupItemMock.mock.calls[0]?.[0] as {
+      name?: string;
       avatar?: { badge?: { status?: string }; image?: { src?: string } };
-    }).avatar;
-    expect(firstCallAvatar?.badge).toEqual({ status: 'available' });
-    expect(firstCallAvatar?.image).toEqual({ src: 'photo-1' });
+    });
+    expect(firstCallAvatar.name).toBe('Adele Vance');
+    const firstCallAvatarProps = firstCallAvatar.avatar;
+    expect(firstCallAvatarProps?.badge).toEqual({ status: 'available' });
+    expect(firstCallAvatarProps?.image).toEqual({ src: 'photo-1' });
 
     expect(avatarGroupPopoverMock).toHaveBeenCalledWith({ count: 1 });
   });

--- a/src/components/People/People.tsx
+++ b/src/components/People/People.tsx
@@ -46,6 +46,7 @@ const renderAvatarGroupItem = (person: PeoplePerson) => {
   return (
     <AvatarGroupItem
       key={person.id}
+      name={label}
       avatar={{
         name: label,
         image: person.photoUrl ? { src: person.photoUrl } : undefined,


### PR DESCRIPTION
This pull request addresses an issue with the `People` component's overflow popovers by ensuring that each person's name is displayed alongside their avatar. The changes improve both the component's rendering and its test coverage.

**People component improvements:**

* Updated the `renderAvatarGroupItem` function in `People.tsx` to pass the `name` prop to `AvatarGroupItem`, ensuring names are shown with avatars in overflow popovers.

**Test coverage updates:**

* Enhanced the `People` component tests to verify that the `name` prop is correctly provided and rendered for each avatar in the popover.

**Documentation/Changelog:**

* Added a changeset describing the fix for the `People` overflow popovers to show each person's name.