### PR TITLE
Fix avatar initials from person name parts

### DIFF
--- a/.changeset/fetch-person-name-parts.md
+++ b/.changeset/fetch-person-name-parts.md
@@ -1,0 +1,5 @@
+---
+'@devsym/graph-toolkit-react': patch
+---
+
+Fetch first and last names with person data so avatar initials prefer them over display names.

--- a/src/__tests__/Person.test.tsx
+++ b/src/__tests__/Person.test.tsx
@@ -449,7 +449,7 @@ describe('Person', () => {
         render(
             <Person
                 personDetails={{
-                    displayName: 'Adele Vance Dispalyname',
+                    displayName: 'Adele Vance Displayname',
                     givenName: 'Adele',
                     surname: null,
                 }}

--- a/src/__tests__/Person.test.tsx
+++ b/src/__tests__/Person.test.tsx
@@ -445,6 +445,24 @@ describe('Person', () => {
         expect(avatar.initials).toBe('AV');
     });
 
+    it('falls back to displayName initials when only one name part is available', () => {
+        render(
+            <Person
+                personDetails={{
+                    displayName: 'Adele Vance Dispalyname',
+                    givenName: 'Adele',
+                    surname: null,
+                }}
+                fetchImage={false}
+            />
+        );
+
+        const personaProps = getLastPersonaProps();
+        const avatar = personaProps.avatar as { initials?: string };
+
+        expect(avatar.initials).toBe('AD');
+    });
+
     it('falls back to the display name first and last words when givenName and surname are missing', () => {
         render(
             <Person

--- a/src/__tests__/usePersonData.test.tsx
+++ b/src/__tests__/usePersonData.test.tsx
@@ -199,6 +199,8 @@ describe('usePersonData caching', () => {
     // all defaults should still be present
     expect(selectedFields).toContain('id');
     expect(selectedFields).toContain('displayName');
+    expect(selectedFields).toContain('givenName');
+    expect(selectedFields).toContain('surname');
     // no empty strings in select
     expect(selectedFields.every((f) => f.length > 0)).toBe(true);
   });

--- a/src/hooks/usePersonData.ts
+++ b/src/hooks/usePersonData.ts
@@ -35,6 +35,8 @@ export interface UsePersonDataOptions {
 const DEFAULT_USER_SELECT_FIELDS = [
   'id',
   'displayName',
+  'givenName',
+  'surname',
   'jobTitle',
   'mail',
   'department',

--- a/src/utils/graph.ts
+++ b/src/utils/graph.ts
@@ -57,18 +57,8 @@ export const getInitials = (nameOrDisplayName?: InitialsNameParts | string): str
   const surname = nameParts?.surname?.trim();
   const displayName = nameParts?.displayName?.trim();
 
-  let initials = '';
-
-  if (givenName) {
-    initials += givenName[0]?.toUpperCase() ?? '';
-  }
-
-  if (surname) {
-    initials += surname[0]?.toUpperCase() ?? '';
-  }
-
-  if (initials) {
-    return initials;
+  if (givenName && surname) {
+    return `${givenName[0]}${surname[0]}`.toUpperCase();
   }
 
   if (!displayName) {


### PR DESCRIPTION
## Summary
- fetch givenName and surname in the default person Graph selection
- ensure avatar initials use the first and last name instead of a multi-word display name
- add a regression test and patch changeset

## Validation
- npm test -- usePersonData.test.tsx
- npm run type-check
- npm run lint