### PR TITLE
Fix direct People entries being resolved through Graph

### DIFF
--- a/src/__tests__/usePeopleList.test.ts
+++ b/src/__tests__/usePeopleList.test.ts
@@ -40,7 +40,7 @@ describe('usePeopleList', () => {
     mockedUseProviderState.mockReturnValue('SignedIn');
   });
 
-  it('enriches supplied people that are missing photos even when presence is disabled', async () => {
+  it('renders supplied people directly without resolving missing photos from Graph', async () => {
     const getPersonData = vi.fn().mockResolvedValue({
       user: {
         id: 'user-1',
@@ -74,54 +74,13 @@ describe('usePeopleList', () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(getPersonData).toHaveBeenCalledWith({
-      identifier: 'user-1',
-      fetchPresence: false,
-      fetchPhoto: true,
-    });
-    expect(result.current.people[0]?.photoUrl).toBe('data:image/png;base64,AAAA');
-  });
-
-  it('prefers userPrincipalName or mail over a local id when enriching supplied people', async () => {
-    const getPersonData = vi.fn().mockResolvedValue({
-      user: {
+    expect(getPersonData).not.toHaveBeenCalled();
+    expect(result.current.people).toEqual([
+      {
         id: 'user-1',
         displayName: 'Adele Vance',
-        mail: 'adelev@contoso.com',
-        userPrincipalName: 'adelev@contoso.com',
       },
-      presence: null,
-      photoUrl: 'data:image/png;base64,AAAA',
-    });
-
-    mockedUseProvider.mockReturnValue({
-      getPersonData,
-    } as IProvider & IPersonDataProvider as never);
-
-    const { result } = renderHook(() =>
-      usePeopleList({
-        people: [
-          {
-            id: 'adele',
-            displayName: 'Adele Vance',
-            mail: 'adelev@contoso.com',
-          },
-        ],
-        showPresence: false,
-      })
-    );
-
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false);
-    });
-
-    expect(getPersonData).toHaveBeenCalledTimes(1);
-    expect(getPersonData).toHaveBeenNthCalledWith(1, {
-      identifier: 'adelev@contoso.com',
-      fetchPresence: false,
-      fetchPhoto: true,
-    });
-    expect(result.current.people[0]?.photoUrl).toBe('data:image/png;base64,AAAA');
+    ]);
   });
 
   it('returns loading=true when a new fetch starts after provider state changes', async () => {

--- a/src/hooks/usePeopleList.ts
+++ b/src/hooks/usePeopleList.ts
@@ -114,17 +114,6 @@ const mergePresence = (person: PeoplePerson, presence: Presence | null): PeopleP
 const resolveIdentifier = (person: Pick<PeoplePerson, 'id' | 'userPrincipalName' | 'mail'>): string | undefined =>
   person.id ?? person.userPrincipalName ?? person.mail ?? undefined;
 
-/**
- * Resolve the best identifier for app-supplied direct people where `id` may be a local key.
- *
- * @param person - Directly supplied person data from application code
- * @returns A Graph-resolvable identifier, preferring UPN/mail before a local `id`
- */
-const resolveDirectPersonIdentifier = (
-  person: Pick<PeoplePerson, 'id' | 'userPrincipalName' | 'mail'>
-): string | undefined =>
-  person.userPrincipalName ?? person.mail ?? person.id ?? undefined;
-
 const uniqueNonEmpty = (values?: string[]): string[] =>
   Array.from(new Set((values ?? []).map(value => value.trim()).filter(Boolean)));
 
@@ -362,13 +351,8 @@ export const usePeopleList = (options?: UsePeopleListOptions): UsePeopleListResu
       }
 
       if (directPeople) {
-        const shouldEnrichResolvedPeople =
-          showPresence || directPeople.some(person => !person.photoUrl);
-        const nextPeople = shouldEnrichResolvedPeople
-          ? await enrichResolvedPeople(directPeople, resolveDirectPersonIdentifier)
-          : directPeople;
         if (!cancelled) {
-          setState({ people: sortPeople(nextPeople, sortBy, sortDirection), loading: false, error: null });
+          setState({ people: sortPeople(directPeople, sortBy, sortDirection), loading: false, error: null });
         }
         return;
       }


### PR DESCRIPTION
## Summary

- render app-supplied `People` entries directly instead of fetching absent photos from Microsoft Graph
- prevent the React MSAL sample's placeholder Contoso identities from issuing `/users/{upn}` requests and crashing the People page
- add regression coverage and a patch changeset

## Validation

- `npm test -- usePeopleList.test.ts`
- `npm run type-check`
- `npm run build`
- `npm run build` in `samples/react-msal-sample`

No visual UI changes; supplied people continue to render with their provided image or initials.