### PR TITLE
Refresh cached person data for avatar initials

### DIFF
--- a/.changeset/refresh-cached-avatar-name-parts.md
+++ b/.changeset/refresh-cached-avatar-name-parts.md
@@ -1,0 +1,5 @@
+---
+'@devsym/graph-toolkit-react': patch
+---
+
+Refresh cached person data that lacks first and last names so avatar initials use current Graph profile fields.

--- a/samples/react-msal-sample/src/PeoplePickerPage.tsx
+++ b/samples/react-msal-sample/src/PeoplePickerPage.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
-import { PeoplePicker } from '@devsym/graph-toolkit-react';
+import { PeoplePicker, Person } from '@devsym/graph-toolkit-react';
 import type { PeoplePickerPerson } from '@devsym/graph-toolkit-react';
 import {
   Body1,
   Body2,
-  Badge,
   Card,
   Title3,
   makeStyles,
@@ -46,14 +45,6 @@ const useStyles = makeStyles({
     flexDirection: 'column',
     gap: '8px',
   },
-  selectedItem: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-    padding: '8px 12px',
-    backgroundColor: tokens.colorNeutralBackground2,
-    borderRadius: tokens.borderRadiusMedium,
-  },
 });
 
 export const PeoplePickerPage: React.FC = () => {
@@ -87,28 +78,14 @@ export const PeoplePickerPage: React.FC = () => {
         {selectedPeople.length > 0 && (
           <div className={styles.selectedList}>
             <Body2>Selected people ({selectedPeople.length}):</Body2>
-            {selectedPeople.map(person => {
-              const label =
-                person.displayName ??
-                person.mail ??
-                person.userPrincipalName ??
-                person.id;
-              return (
-                <div key={person.id} className={styles.selectedItem}>
-                  <Badge appearance="filled" color="brand" shape="circular">
-                    {label.charAt(0).toUpperCase()}
-                  </Badge>
-                  <div>
-                    <Body2>{label}</Body2>
-                    {person.mail && person.mail !== label && (
-                      <Body1 style={{ color: tokens.colorNeutralForeground3 }}>
-                        {person.mail}
-                      </Body1>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
+            {selectedPeople.map(person => (
+              <Person
+                key={person.id}
+                personDetails={person}
+                view="threelines"
+                fetchImage={false}
+              />
+            ))}
           </div>
         )}
       </div>

--- a/samples/react-msal-sample/src/PeoplePickerPage.tsx
+++ b/samples/react-msal-sample/src/PeoplePickerPage.tsx
@@ -81,7 +81,7 @@ export const PeoplePickerPage: React.FC = () => {
             {selectedPeople.map(person => (
               <Person
                 key={person.id}
-                personDetails={person}
+                userId={person.id}
                 view="threelines"
                 fetchImage={false}
               />

--- a/src/__tests__/usePersonData.test.tsx
+++ b/src/__tests__/usePersonData.test.tsx
@@ -60,6 +60,8 @@ describe('usePersonData caching', () => {
     const cachedUser = {
       id: 'user-1',
       displayName: 'Cached User',
+      givenName: 'Cached',
+      surname: 'User',
       userPrincipalName: 'cached@contoso.com',
     } as User;
 
@@ -97,12 +99,62 @@ describe('usePersonData caching', () => {
     expect(mockedWritePersonCache).not.toHaveBeenCalled();
   });
 
+  it('refreshes a cached user that predates the default name-part selection', async () => {
+    const now = Date.now();
+    const selectMock = vi.fn().mockReturnValue({
+      get: vi.fn().mockResolvedValue({
+        id: 'user-1',
+        displayName: 'Adele Vance Displayname',
+        givenName: 'Adele',
+        surname: 'Vance',
+      }),
+    });
+    const apiMock = vi.fn().mockReturnValue({ select: selectMock });
+    mockedUseGraphClient.mockReturnValue({ api: apiMock } as never);
+    mockedReadPersonCache.mockResolvedValue({
+      user: {
+        id: 'user-1',
+        displayName: 'Adele Vance Displayname',
+      } as User,
+      userCachedAt: now,
+    });
+
+    const { result } = renderHook(() =>
+      usePersonData({
+        userId: 'user-1',
+        fetchPresence: false,
+        fetchPhoto: false,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(apiMock).toHaveBeenCalledWith('/users/user-1');
+    expect(result.current.user).toMatchObject({
+      givenName: 'Adele',
+      surname: 'Vance',
+    });
+    expect(mockedWritePersonCache).toHaveBeenCalledWith(
+      'person:user-1',
+      expect.objectContaining({
+        user: expect.objectContaining({
+          givenName: 'Adele',
+          surname: 'Vance',
+        }),
+      })
+    );
+  });
+
   it('reuses cached user and refreshes stale presence only', async () => {
     const now = Date.now();
     const stale = now - 10 * 60 * 1000;
     const cachedUser = {
       id: 'user-1',
       displayName: 'Cached User',
+      givenName: 'Cached',
+      surname: 'User',
       userPrincipalName: 'cached@contoso.com',
     } as User;
 

--- a/src/hooks/usePersonData.ts
+++ b/src/hooks/usePersonData.ts
@@ -44,6 +44,13 @@ const DEFAULT_USER_SELECT_FIELDS = [
   'userPrincipalName',
 ];
 
+const hasNameParts = (user: User): boolean => {
+  return (
+    Object.prototype.hasOwnProperty.call(user, 'givenName') &&
+    Object.prototype.hasOwnProperty.call(user, 'surname')
+  );
+};
+
 /**
  * Fetch person data from Microsoft Graph
  */
@@ -146,7 +153,9 @@ export const usePersonData = (options: UsePersonDataOptions): PersonData => {
       const cacheKey = getPersonCacheKey(identifier);
       const cached = personCacheOptions.enabled ? await readPersonCache(cacheKey) : null;
       const hasFreshUser = Boolean(
-        cached?.user && isTimestampFresh(cached.userCachedAt, personCacheOptions.userTtlMs)
+        cached?.user &&
+          hasNameParts(cached.user) &&
+          isTimestampFresh(cached.userCachedAt, personCacheOptions.userTtlMs)
       );
       const hasFreshPresence = Boolean(
         cached?.presenceCachedAt &&


### PR DESCRIPTION
## Summary
- refresh cached users that predate selection of givenName and surname`n- preserve cache reuse for entries that explicitly contain both name properties
- add a regression test and patch changeset

## Validation
- npm test
- npm run type-check
- npm run lint